### PR TITLE
fix:scroll issue +file-disable

### DIFF
--- a/app/(dashboard)/dashboard/_components/file-display.tsx
+++ b/app/(dashboard)/dashboard/_components/file-display.tsx
@@ -44,6 +44,7 @@ function MultiImageExample({updateData}) {
     <div className="flex flex-col items-center">
       <MultiFileDropzone
         value={fileStates}
+        disabled ={uploadRes.length > 0}
         dropzoneOptions={{
           maxFiles: 10,
           maxSize: 1024 * 1024 * 100, // 1 MB

--- a/app/(dashboard)/dashboard/_components/upload-form.tsx
+++ b/app/(dashboard)/dashboard/_components/upload-form.tsx
@@ -88,7 +88,7 @@ const FileForm = ({ userId }: UserProps) => {
                     Upload File
                 </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[500px] !overflow-y-scroll !max-h-screen !py-2 !overflow-x-hidden bg-gradient-to-tr from-purple-400/15 via-transparent to-transparent/70">
+            <DialogContent className="sm:max-w-[500px] py-4 overflow-hidden bg-gradient-to-tr from-purple-400/15 via-transparent to-transparent/70">
                 <DialogHeader>
                     <DialogTitle>Upload a file</DialogTitle>
                     <DialogDescription>
@@ -98,7 +98,9 @@ const FileForm = ({ userId }: UserProps) => {
 
 
                 </DialogHeader>
-                <FuzzyOverlay />
+                
+                    <FuzzyOverlay />
+                
                 <form onSubmit={onSubmit}>
                     <div className="grid gap-4 py-4">
                         <div className="grid grid-cols-4 items-center gap-4">
@@ -135,8 +137,10 @@ const FileForm = ({ userId }: UserProps) => {
                                 Upload A File
                             </span>
                         </div>
-                        <div className="flex justify-center items-center">
-                            <FilePage updateData={handleParentUpdate} />
+                        <div   className="flex justify-center items-center">
+                            {
+                               <FilePage updateData={handleParentUpdate} />
+                                }
                         </div>
                     </div>
                     <DialogFooter>

--- a/app/(dashboard)/dashboard/logs/_components/logs-analytics.tsx
+++ b/app/(dashboard)/dashboard/logs/_components/logs-analytics.tsx
@@ -10,6 +10,9 @@ import { Separator } from "@/components/ui/separator"
 import { type Logs } from "@prisma/client"
 import LogsDisplay from "./log-display"
 import LogMenu from "./log-menu"
+import { EmptyPlaceholder } from "@/components/shared/empty-placeholder"
+import { files } from "@/lib/fille"
+import { PipetteIcon } from "lucide-react"
 
 export function LogsAnalytics({ logs }: { logs: Logs[] }) {
   if (!logs) {
@@ -41,11 +44,20 @@ export function LogsAnalytics({ logs }: { logs: Logs[] }) {
             </div>
           </div>
           <div className="border rounded-lg bg-purple-900/5 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(217,176,225,0.12),rgba(255,255,255,0))]  text-card-foreground overflow-hidden grid gap-4 lg:gap-px ">
-            {logs.map((log) => {
+            
+            {
+            logs.length>0?(
+            logs.map((log) => {
               return (
+                
                 <LogsDisplay log={log} />
               )
-            })}
+            })
+            ):
+            (
+              <EmptyLog/>
+            )
+          }
 
 
           </div>
@@ -188,4 +200,26 @@ function MoreHorizontalIcon(props) {
       <circle cx="5" cy="12" r="1" />
     </svg>
   )
+}
+
+
+
+
+function EmptyLog(){
+  
+return (
+  <EmptyPlaceholder className="relative bg-gradient-to-tr from-purple-400/10 rounded-lg  via-transparent to-transparent/5 w-full flex justify-start ">
+  <PipetteIcon size={45}/>
+
+  <EmptyPlaceholder.Title className="font-heading text-3xl"> 
+    No logs found
+  </EmptyPlaceholder.Title>
+  <EmptyPlaceholder.Description>
+    <span className="">Your logs will be recorded once you or someone attempts to read you file</span>
+  </EmptyPlaceholder.Description>
+
+
+</EmptyPlaceholder>
+
+)
 }


### PR DESCRIPTION
this pr introduces the following changes 

- disables the file drope-zone after a successful file upload 
- fixes scroll glitch on the upload file dialog.
- Adds EmptyLog component which is shown when there are no logs to show